### PR TITLE
use indexOf instead of includes for better compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.parse = function(str){
     var key = decode(parts[0]);
     var m;
     // Sanitize keys to uppercase to mitigate client-side prototype pollution
-    if (key && ["__proto__", "constructor", "prototype"].includes(key.toLowerCase())) {
+    if (key && ["__proto__", "constructor", "prototype"].indexOf(key.toLowerCase()) > -1) {
       key = key.toUpperCase()
     }
 


### PR DESCRIPTION
@tomharrisonjr's fix was great, but unfortunately doesn't work with older versions of Node. `indexOf` provides similar functionality, but is compatible with older versions.

Where `haystack.includes(needle)` returns `true` / `false` if the needle exists in the haystack, `haystack.indexOf(needle)` returns the index of the needle if present in the haystack or `-1` if the needle is not present.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf